### PR TITLE
Added support for a Proc as an api_key

### DIFF
--- a/lib/alphavantage/configuration.rb
+++ b/lib/alphavantage/configuration.rb
@@ -10,6 +10,23 @@ module Alphavantage
   end
 
   class Configuration
-    attr_accessor :api_key
+    # Allows @api_key to be a Proc, for example
+    # as an API Key Manager or Rate Limiter.
+    #
+    def api_key
+      if @api_key.is_a?(Proc)
+        @api_key.call
+      else
+        @api_key
+      end
+    end
+
+
+    # Typically an_object is a String but
+    # it can also be a Proc
+    #
+    def api_key=(an_object)
+      @api_key = an_object
+    end
   end
 end

--- a/spec/alphavantage/configuration_spec.rb
+++ b/spec/alphavantage/configuration_spec.rb
@@ -10,4 +10,22 @@ describe Alphavantage::Configuration do
 
     expect(Alphavantage.configuration.api_key).to eq('someKey')
   end
+
+  # Why is this important?  Because some API keys are rate limited.  Having
+  # a Oroc as an api_key allows the user to inject an API Key Manager
+  # or rate limiter process.
+  #
+  it "should support a Proc as an api_key" do
+    Alphavantage.configure do |config|
+      config.api_key = -> { Time.now }
+    end
+
+    key1 = Alphavantage.configuration.api_key
+    sleep(1)
+    key2 = Alphavantage.configuration.api_key
+
+    expect(key1.class).to   eq(Time)
+    expect(key2.class).to   eq(Time)
+    expect(key1 < Key2).to  be(true)
+  end
 end

--- a/spec/alphavantage/configuration_spec.rb
+++ b/spec/alphavantage/configuration_spec.rb
@@ -11,8 +11,8 @@ describe Alphavantage::Configuration do
     expect(Alphavantage.configuration.api_key).to eq('someKey')
   end
 
-  # Why is this important?  Because some API keys are rate limited.  Having
-  # a Oroc as an api_key allows the user to inject an API Key Manager
+  # Why is this important? Because some API keys are rate limited.  Having
+  # a proc as an api_key allows the user to inject an API Key Manager
   # or rate limiter process.
   #
   it "should support a Proc as an api_key" do


### PR DESCRIPTION
This PR allows the api_key to be configured as a Proc.

When the api_key is a Proc, that functional can be an API Key Manager or Rate Limter process.  This way a user of the alphavantage API can take advantage of their free, rate limited api keys to do development and testing of their code.

An example of such a function is the ApiKeyManager class I have in my lib_ruby repository.